### PR TITLE
feat: 상품 상세 보기 HTML에서 이미지 URL 추출

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -53,7 +53,7 @@ public class OpenAiClient {
 
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(request.urls(), prompt, DetailExplanationResponse.class);
+        return callWithStructuredOutput(urls, prompt, DetailExplanationResponse.class);
     }
 
     public AllergyAiResponse explainAllergy(FoodProductAnalysisRequest request) {

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -39,7 +39,7 @@ public class OpenAiClient {
     private final ChatClient chatClient;
 
 
-    public DetailExplanationResponse explainProductDetail(OutlineType outline, ProductDetailAnalysisRequest request) {
+    public DetailExplanationResponse explainProductDetail(OutlineType outline, List<String> urls) {
         String system = """
                 You are an expert in providing detailed explanations about products based on images.
                 When a user provides a product description image along with the key outline of that description, you should offer a clear and detailed explanation of that element.

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -18,11 +18,20 @@ import com.webeye.backend.product.dto.request.ProductDetailAnalysisRequest;
 import com.webeye.backend.product.dto.response.ProductResponse;
 import com.webeye.backend.product.persistent.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -73,7 +82,20 @@ public class ProductService {
     }
 
     public DetailExplanationResponse analyzeProductDetail(OutlineType outline, ProductDetailAnalysisRequest request) {
-        return openAiClient.explainProductDetail(outline, request);
+        return openAiClient.explainProductDetail(outline, extractImageUrlFromHtml(request.html()));
     }
 
+    private List<String> extractImageUrlFromHtml(String html) {
+        Pattern pattern = Pattern.compile("<img[^>]+src=[\"'](//[^\"']+)[\"']");
+        Matcher matcher = pattern.matcher(html);
+
+        List<String> imageUrls = new ArrayList<>();
+
+        while (matcher.find()) {
+            String rawUrl = matcher.group(1);
+            String fullUrl = "https:" + rawUrl;
+            imageUrls.add(fullUrl);
+        }
+        return imageUrls;
+    }
 }

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -19,10 +19,6 @@ import com.webeye.backend.product.dto.response.ProductResponse;
 import com.webeye.backend.product.persistent.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -92,6 +92,9 @@ public class ProductService {
             String fullUrl = "https:" + rawUrl;
             imageUrls.add(fullUrl);
         }
+        log.info("extracted urls: {}", imageUrls);
+        log.info("total number of images: {}", imageUrls.size());
+
         return imageUrls;
     }
 }

--- a/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
@@ -4,13 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
-import java.util.List;
-
-@Schema(description = "상품 설명 이미지의 URL")
+@Schema(description = "상품 설명 이미지의 HTML")
 @Builder
 public record ProductDetailAnalysisRequest(
-        @Schema(description = "상품 이미지 URL")
+        @Schema(description = "상품 상세 이미지")
         @NotEmpty(message = "이미지 URL 목록은 비어있을 수 없습니다.")
-        List<String> urls
+        String html
 ){
 }

--- a/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
@@ -7,8 +7,8 @@ import lombok.Builder;
 @Schema(description = "상품 설명 이미지의 HTML")
 @Builder
 public record ProductDetailAnalysisRequest(
-        @Schema(description = "상품 상세 이미지")
-        @NotEmpty(message = "이미지 URL 목록은 비어있을 수 없습니다.")
+        @Schema(description = "상품 상세 정보 HTML")
+        @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
         String html
 ){
 }

--- a/src/main/java/com/webeye/backend/product/presentation/swagger/ProductSwagger.java
+++ b/src/main/java/com/webeye/backend/product/presentation/swagger/ProductSwagger.java
@@ -32,7 +32,7 @@ public interface ProductSwagger {
 
     @Operation(
             summary = "제품 주요 개요에 대한 상세 설명 추출",
-            description = "제품 설명 이미지와 개요를 입력받아 주요 요소에 대한 상세 설명을 추출합니다. " +
+            description = "제품 상세 설명 이미지가 포함된 HTML과 개요를 입력받아 주요 요소에 대한 상세 설명을 추출합니다. " +
                     "MAIN: 주요정보, USAGE: 사용정보, WARNING: 주의 및 보관, SPECS: 규격 및 옵션, CERTIFICATION: 인증 및 기타"
     )
     @ApiResponses(value = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #49 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 상품 상세 보기의 이미지 URL을 전달받은 HTML에서 추출합니다.

## 📸 스크린샷
<img width="1218" alt="스크린샷 2025-05-17 오후 6 19 07" src="https://github.com/user-attachments/assets/6ad910a8-df50-48b2-943e-ace84014b244" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 상품 상세 이미지 분석 요청 시 HTML 입력을 지원합니다.

- **문서**
	- 상품 상세 이미지 분석 관련 설명이 HTML 입력 방식으로 변경되었습니다.

- **버그 수정**
	- 이미지 URL 추출 로직이 HTML에서 자동으로 추출되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->