### PR TITLE
refactor: 상품 상세 정보의 이미지를 URL로 받는 API를 HTML로 받도록 수정

### DIFF
--- a/src/main/java/com/webeye/backend/allergy/application/AllergyService.java
+++ b/src/main/java/com/webeye/backend/allergy/application/AllergyService.java
@@ -1,6 +1,7 @@
 package com.webeye.backend.allergy.application;
 
 import com.webeye.backend.allergy.dto.response.AllergyAiResponse;
+import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
 import com.webeye.backend.product.dto.request.FoodProductAnalysisRequest;
 import com.webeye.backend.imageanalysis.infrastructure.OpenAiClient;
 import com.webeye.backend.product.domain.Product;
@@ -14,10 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AllergyService {
     private final OpenAiClient openAiClient;
+    private final ImageUrlExtractor imageUrlExtractor;
     private final ProductRepository productRepository;
 
     public AllergyAiResponse analyzeAllergy(FoodProductAnalysisRequest request) {
-        return openAiClient.explainAllergy(request);
+        return openAiClient.explainAllergy(imageUrlExtractor.extractImageUrlFromHtml(request.html()));
     }
 
     @Transactional

--- a/src/main/java/com/webeye/backend/cosmetic/application/CosmeticServiceImpl.java
+++ b/src/main/java/com/webeye/backend/cosmetic/application/CosmeticServiceImpl.java
@@ -1,6 +1,7 @@
 package com.webeye.backend.cosmetic.application;
 
 import com.webeye.backend.cosmetic.dto.response.CosmeticResponse;
+import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
 import com.webeye.backend.imageanalysis.infrastructure.OpenAiClient;
 import com.webeye.backend.product.dto.request.ProductAnalysisRequest;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,10 @@ import org.springframework.stereotype.Service;
 public class CosmeticServiceImpl implements CosmeticService {
 
     private final OpenAiClient openAiClient;
+    private final ImageUrlExtractor imageUrlExtractor;
 
     @Override
     public CosmeticResponse analyzeCosmetic(ProductAnalysisRequest request) {
-        return openAiClient.explainCosmetic(request);
+        return openAiClient.explainCosmetic(imageUrlExtractor.extractImageUrlFromHtml(request.html()));
     }
 }

--- a/src/main/java/com/webeye/backend/global/error/ErrorCode.java
+++ b/src/main/java/com/webeye/backend/global/error/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     UNSUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL입니다."),
 
+    // image url extract
+    IMAGE_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지의 URL이 추출되지 않았습니다."),
+
     // open api
     OPEN_API_RESPONSE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "Open API 응답에 실패했습니다."),
     OPEN_API_DATA_MISSING(HttpStatus.NOT_FOUND, "Open API 데이터가 존재하지 않습니다."),

--- a/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
+++ b/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
@@ -11,6 +11,7 @@ import com.webeye.backend.healthfood.infrastructure.client.HealthFoodClient;
 import com.webeye.backend.healthfood.infrastructure.mapper.HealthFoodMapper;
 import com.webeye.backend.healthfood.infrastructure.mapper.ProductHealthFoodMapper;
 import com.webeye.backend.healthfood.infrastructure.persistence.HealthFoodRepository;
+import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
 import com.webeye.backend.imageanalysis.infrastructure.OpenAiClient;
 import com.webeye.backend.product.domain.Product;
 import com.webeye.backend.product.domain.ProductHealthfood;
@@ -37,6 +38,7 @@ public class HealthFoodService {
     private String serviceKey;
 
     private final OpenAiClient openAiClient;
+    private final ImageUrlExtractor imageUrlExtractor;
     private final HealthFoodClient healthFoodClient;
     private final ProductRepository productRepository;
     private final HealthFoodRepository healthFoodRepository;
@@ -80,7 +82,7 @@ public class HealthFoodService {
     }
 
     public HealthFoodAiResponse analyzeHealthFood(FoodProductAnalysisRequest request) {
-        return openAiClient.explainHealthFood(request);
+        return openAiClient.explainHealthFood(imageUrlExtractor.extractImageUrlFromHtml(request.html()));
     }
 
     @Transactional

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -1,0 +1,30 @@
+package com.webeye.backend.imageanalysis.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class ImageUrlExtractor {
+    public List<String> extractImageUrlFromHtml(String html) {
+        Pattern pattern = Pattern.compile("<img[^>]+src=[\"'](//[^\"']+)[\"']");
+        Matcher matcher = pattern.matcher(html);
+
+        List<String> imageUrls = new ArrayList<>();
+
+        while (matcher.find()) {
+            String rawUrl = matcher.group(1);
+            String fullUrl = "https:" + rawUrl;
+            imageUrls.add(fullUrl);
+        }
+        log.info("extracted urls: {}", imageUrls);
+        log.info("total number of images: {}", imageUrls.size());
+
+        return imageUrls;
+    }
+}

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -1,5 +1,7 @@
 package com.webeye.backend.imageanalysis.infrastructure;
 
+import com.webeye.backend.global.error.BusinessException;
+import com.webeye.backend.global.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +27,9 @@ public class ImageUrlExtractor {
         log.info("extracted urls: {}", imageUrls);
         log.info("total number of images: {}", imageUrls.size());
 
+        if (imageUrls.isEmpty()) {
+            throw new BusinessException(ErrorCode.IMAGE_URL_NOT_FOUND);
+        }
         return imageUrls;
     }
 }

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -12,7 +12,6 @@ import com.webeye.backend.imageanalysis.dto.request.ImageAnalysisPrompt;
 import com.webeye.backend.product.domain.type.OutlineType;
 import com.webeye.backend.product.dto.request.FoodProductAnalysisRequest;
 import com.webeye.backend.nutrition.dto.response.NutritionAiResponse;
-import com.webeye.backend.product.dto.request.ProductDetailAnalysisRequest;
 import com.webeye.backend.rawmaterial.dto.response.RawMaterialAiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +55,7 @@ public class OpenAiClient {
         return callWithStructuredOutput(urls, prompt, DetailExplanationResponse.class);
     }
 
-    public AllergyAiResponse explainAllergy(FoodProductAnalysisRequest request) {
+    public AllergyAiResponse explainAllergy(List<String> urls) {
         String system = """
                 You are an OCR assistant that extracts and detects allergenic ingredients from Korean product label images. Always treat partial matches inside compound words as valid if they contain the full Korean name of an allergen.
                                                                                
@@ -82,10 +81,10 @@ public class OpenAiClient {
                  """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(request.urls(), prompt, AllergyAiResponse.class);
+        return callWithStructuredOutput(urls, prompt, AllergyAiResponse.class);
     }
 
-    public NutritionAiResponse explainNutrition(FoodProductAnalysisRequest request) {
+    public NutritionAiResponse explainNutrition(List<String> urls) {
         String system = """
                 You are a nutrition description assistant.
                 """;
@@ -96,11 +95,11 @@ public class OpenAiClient {
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(request.urls(), prompt, NutritionAiResponse.class);
+        return callWithStructuredOutput(urls, prompt, NutritionAiResponse.class);
     }
 
 
-    public CosmeticResponse explainCosmetic(ProductAnalysisRequest request) {
+    public CosmeticResponse explainCosmetic(List<String> urls) {
         String system = """
                 You are an expert in identifying harmful cosmetic ingredients based on Korean labels.
                 You always return exact matches based on a predefined Korean-to-English mapping.
@@ -140,10 +139,10 @@ public class OpenAiClient {
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(request.urls(), prompt, CosmeticResponse.class);
+        return callWithStructuredOutput(urls, prompt, CosmeticResponse.class);
     }
 
-    public HealthFoodAiResponse explainHealthFood(FoodProductAnalysisRequest request) {
+    public HealthFoodAiResponse explainHealthFood(List<String> urls) {
         String system = """
                 You are a food label OCR expert. Your task is to extract ingredient names from Korean health supplement product images.
                 You must return only a list of ingredient names, in JSON format. Do not summarize or explain anything.
@@ -176,7 +175,7 @@ public class OpenAiClient {
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(request.urls(), prompt, HealthFoodAiResponse.class);
+        return callWithStructuredOutput(urls, prompt, HealthFoodAiResponse.class);
     }
 
     public ImageAnalysisResponse explainImage(ImageAnalysisRequest request) {

--- a/src/main/java/com/webeye/backend/imageanalysis/presentation/swagger/ImageAnalysisSwagger.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/presentation/swagger/ImageAnalysisSwagger.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[이미지 분석]", description = "이미지 분석 관련 API")
 public interface ImageAnalysisSwagger {
     @Operation(
-            summary = "[이미지 분석]",
+            summary = "이미지 분석",
             description = "이미지 URL을 입력받아 이미지를 분석을 제공합니다."
     )
     @ApiResponses(value = {

--- a/src/main/java/com/webeye/backend/nutrition/application/NutritionService.java
+++ b/src/main/java/com/webeye/backend/nutrition/application/NutritionService.java
@@ -2,6 +2,7 @@ package com.webeye.backend.nutrition.application;
 
 import com.webeye.backend.global.error.BusinessException;
 import com.webeye.backend.global.error.ErrorCode;
+import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
 import com.webeye.backend.product.dto.request.FoodProductAnalysisRequest;
 import com.webeye.backend.imageanalysis.infrastructure.OpenAiClient;
 import com.webeye.backend.nutrition.domain.Nutrient;
@@ -24,6 +25,7 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class NutritionService {
     private final OpenAiClient openAiClient;
+    private final ImageUrlExtractor imageUrlExtractor;
     private final RawMaterialService rawMaterialService;
 
     private final NutrientRepository nutrientRepository;
@@ -36,7 +38,7 @@ public class NutritionService {
 
     @Transactional
     public void saveProductNutrition(Product product, FoodProductAnalysisRequest request) {
-        NutritionAiResponse response = openAiClient.explainNutrition(request);
+        NutritionAiResponse response = openAiClient.explainNutrition(imageUrlExtractor.extractImageUrlFromHtml(request.html()));
         if (Boolean.TRUE.equals(response.isNutrientIncluded())) {
             Map<NutrientType, Double> nutrientMap = extractNutrientMap(response);
 

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -2,6 +2,7 @@ package com.webeye.backend.product.application;
 
 import com.webeye.backend.allergy.application.AllergyService;
 import com.webeye.backend.allergy.type.AllergyType;
+import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
 import com.webeye.backend.product.dto.response.DetailExplanationResponse;
 import com.webeye.backend.global.error.BusinessException;
 import com.webeye.backend.global.error.ErrorCode;
@@ -22,10 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -36,6 +34,7 @@ public class ProductService {
     private final NutrientRecommendationService nutrientRecommendationService;
     private final AllergyService allergyService;
     private final OpenAiClient openAiClient;
+    private final ImageUrlExtractor imageUrlExtractor;
 
     private final ProductRepository productRepository;
 
@@ -72,29 +71,13 @@ public class ProductService {
                 .toList();
     }
 
-    private List<NutrientRecommendationResponse> getNutrientRecommendationResponse(FoodProductAnalysisRequest request, Product product) {
+    private List<NutrientRecommendationResponse> getNutrientRecommendationResponse(
+            FoodProductAnalysisRequest request, Product product) {
         return nutrientRecommendationService.analyzeNutrientSufficiency(NutrientRecommendationRequest
                 .builder().birthYear(request.birthYear()).gender(request.gender()).product(product).build());
     }
 
     public DetailExplanationResponse analyzeProductDetail(OutlineType outline, ProductDetailAnalysisRequest request) {
-        return openAiClient.explainProductDetail(outline, extractImageUrlFromHtml(request.html()));
-    }
-
-    private List<String> extractImageUrlFromHtml(String html) {
-        Pattern pattern = Pattern.compile("<img[^>]+src=[\"'](//[^\"']+)[\"']");
-        Matcher matcher = pattern.matcher(html);
-
-        List<String> imageUrls = new ArrayList<>();
-
-        while (matcher.find()) {
-            String rawUrl = matcher.group(1);
-            String fullUrl = "https:" + rawUrl;
-            imageUrls.add(fullUrl);
-        }
-        log.info("extracted urls: {}", imageUrls);
-        log.info("total number of images: {}", imageUrls.size());
-
-        return imageUrls;
+        return openAiClient.explainProductDetail(outline, imageUrlExtractor.extractImageUrlFromHtml(request.html()));
     }
 }

--- a/src/main/java/com/webeye/backend/product/dto/request/FoodProductAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/FoodProductAnalysisRequest.java
@@ -20,9 +20,9 @@ public record FoodProductAnalysisRequest(
         @Schema(description = "상품 제목")
         String title,
 
-        @Schema(description = "상품 이미지 URL")
-        @NotEmpty(message = "이미지 URL 목록은 비어있을 수 없습니다.")
-        List<String> urls,
+        @Schema(description = "상품 상세 정보 HTML")
+        @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
+        String html,
 
         @Schema(description = "사용자 출생년도")
         @NotNull(message = "사용자의 출생연도는 비어있을 수 없습니다.")

--- a/src/main/java/com/webeye/backend/product/dto/request/FoodProductAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/FoodProductAnalysisRequest.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 import java.util.List;
@@ -22,6 +23,7 @@ public record FoodProductAnalysisRequest(
 
         @Schema(description = "상품 상세 정보 HTML")
         @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
+        @Pattern(regexp = ".*<img.*src=.*>.*", message = "HTML에는 최소한 하나의 이미지 태그가 포함되어야 합니다.")
         String html,
 
         @Schema(description = "사용자 출생년도")

--- a/src/main/java/com/webeye/backend/product/dto/request/ProductAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/ProductAnalysisRequest.java
@@ -2,6 +2,7 @@ package com.webeye.backend.product.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 @Schema(description = "제품 분석")
@@ -12,6 +13,7 @@ public record ProductAnalysisRequest(
 
         @Schema(description = "상품 상세 정보 HTML")
         @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
+        @Pattern(regexp = ".*<img.*src=.*>.*", message = "HTML에는 최소한 하나의 이미지 태그가 포함되어야 합니다.")
         String html
 ) {
 }

--- a/src/main/java/com/webeye/backend/product/dto/request/ProductAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/ProductAnalysisRequest.java
@@ -4,16 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
-import java.util.List;
-
 @Schema(description = "제품 분석")
 @Builder
 public record ProductAnalysisRequest(
         @NotEmpty(message = "제품 ID는 비어있을 수 없습니다.")
         String productId,
 
-        @Schema(description = "상품 이미지 URL")
-        @NotEmpty(message = "이미지 URL 목록은 비어있을 수 없습니다.")
-        List<String> urls
+        @Schema(description = "상품 상세 정보 HTML")
+        @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
+        String html
 ) {
 }

--- a/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
+++ b/src/main/java/com/webeye/backend/product/dto/request/ProductDetailAnalysisRequest.java
@@ -2,6 +2,7 @@ package com.webeye.backend.product.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 @Schema(description = "상품 설명 이미지의 HTML")
@@ -9,6 +10,7 @@ import lombok.Builder;
 public record ProductDetailAnalysisRequest(
         @Schema(description = "상품 상세 정보 HTML")
         @NotEmpty(message = "상품 상세 정보의 HTML은 비어있을 수 없습니다.")
+        @Pattern(regexp = ".*<img.*src=.*>.*", message = "HTML에는 최소한 하나의 이미지 태그가 포함되어야 합니다.")
         String html
 ){
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #49 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 일반 식품, 건강기능식품, 화장품 API 중 상품 상세 정보의 이미지를 URL로 받는 API를 HTML로 받도록 수정했습니다.

## 📸 스크린샷
- 파프리카가 건강해서 알러지랑 영양성분 권장량 넘는게 없네용 ㅎㅎ. 잘됩니당
<img width="1221" alt="스크린샷 2025-05-17 오후 7 06 44" src="https://github.com/user-attachments/assets/a885a0ab-228f-4622-b5c2-b6eb119d73de" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
`cosmetic` 이랑 `health food`도 수정했어용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - HTML에서 이미지 URL을 추출하는 기능이 도입되었습니다.
  - 이미지 URL 미발견 시 반환되는 새로운 에러 코드가 추가되었습니다.

- **변경 사항**
  - 상품 분석 요청 시 이미지 URL 리스트 대신 HTML 상세 정보를 입력하도록 변경되었습니다.
  - 알레르기, 영양, 건강식품, 화장품 분석 서비스가 HTML에서 추출된 이미지 URL 리스트를 사용하여 AI 분석을 수행합니다.
  - AI 분석 클라이언트가 이미지 URL 리스트를 직접 받아 처리하도록 개선되었습니다.
  - 상품 상세 분석 시 이미지 URL 추출 로직이 공통 컴포넌트로 통합되었습니다.
  - API 요청 DTO에 HTML 내 이미지 태그 존재 여부를 검증하는 패턴 제약이 추가되었습니다.

- **문서**
  - API 문서의 일부 설명에서 대괄호가 제거되어 간결하게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->