### PR TITLE
#63 fix: product nutrient duplicate remove

### DIFF
--- a/src/main/java/com/webeye/backend/product/domain/ProductNutrient.java
+++ b/src/main/java/com/webeye/backend/product/domain/ProductNutrient.java
@@ -33,6 +33,5 @@ public class ProductNutrient extends BaseEntity {
 
     public void associateWithProduct(Product product) {
         this.product = product;
-        product.getNutrients().add(this);
     }
 }


### PR DESCRIPTION
remove product.getNutrients().add(this) of associateWithProduct

## #️⃣ 연관된 이슈

- #63 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- Product Nutrient 가 중복 저장되는 오류를 해결했습니다.

## 📸 스크린샷
<img width="1203" alt="스크린샷 2025-05-22 오후 10 57 03" src="https://github.com/user-attachments/assets/91441dc6-e89f-418d-9821-349cf73cdde0" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 제품 영양소와 제품 간의 연관 설정 시, 제품의 영양소 목록이 중복 추가되는 현상이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->