### PR TITLE
feat: 식품 영양성분 도출 기준 함량 추가

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -92,6 +92,9 @@ public class OpenAiClient {
         String user = """
                 If the attached images contain 'nutrition information', please provide the amount of each nutrient in the format I sent.
                 If the nutritional information is not included, set the isNutrientIncluded field to false; if it is included, set it to true.
+                You are given a nutrition label image. Extract the number of grams that the nutritional values are based on.
+                This is typically written as "per 100g", "per 1 serving (XXg)", "100 g당" (in Korean), or similar.
+                Return only the numeric gram value in a field named nutrientReferenceAmount.
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
@@ -136,6 +139,7 @@ public class OpenAiClient {
                 }
                 Return true only if the exact full Korean ingredient name appears continuously and separately; otherwise, return false.
                 Ignore partial, similar, or incomplete matches.
+                
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);

--- a/src/main/java/com/webeye/backend/nutrition/application/NutritionService.java
+++ b/src/main/java/com/webeye/backend/nutrition/application/NutritionService.java
@@ -11,7 +11,6 @@ import com.webeye.backend.nutrition.dto.response.NutritionAiResponse;
 import com.webeye.backend.nutrition.persistent.NutrientRepository;
 import com.webeye.backend.product.domain.Product;
 import com.webeye.backend.product.domain.ProductNutrient;
-import com.webeye.backend.product.persistent.ProductRepository;
 import com.webeye.backend.rawmaterial.application.RawMaterialService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +28,6 @@ public class NutritionService {
     private final RawMaterialService rawMaterialService;
 
     private final NutrientRepository nutrientRepository;
-    private final ProductRepository productRepository;
 
     public Nutrient findByType(NutrientType type) {
         return nutrientRepository.findByType(type)
@@ -40,6 +38,7 @@ public class NutritionService {
     public void saveProductNutrition(Product product, FoodProductAnalysisRequest request) {
         NutritionAiResponse response = openAiClient.explainNutrition(imageUrlExtractor.extractImageUrlFromHtml(request.html()));
         if (Boolean.TRUE.equals(response.isNutrientIncluded())) {
+            product.setNutrientReferenceAmount(response.nutrientReferenceAmount());
             Map<NutrientType, Double> nutrientMap = extractNutrientMap(response);
 
             nutrientMap.forEach((type, amount) -> {
@@ -53,7 +52,6 @@ public class NutritionService {
                                 .build()
                 );
             });
-            productRepository.save(product);
             return;
         }
         rawMaterialService.saveRawMaterialNutrition(product, request);

--- a/src/main/java/com/webeye/backend/nutrition/dto/response/NutrientResponse.java
+++ b/src/main/java/com/webeye/backend/nutrition/dto/response/NutrientResponse.java
@@ -1,0 +1,16 @@
+package com.webeye.backend.nutrition.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NutrientResponse(
+        @Schema(description = "영양성분 도출 기준 함량(단위: g)")
+        Integer nutrientReferenceAmount,
+
+        @Schema(description = "영양성분 권장량을 넘는 성분")
+        List<NutrientRecommendationResponse> overRecommendationNutrients
+) {
+}

--- a/src/main/java/com/webeye/backend/nutrition/dto/response/NutritionAiResponse.java
+++ b/src/main/java/com/webeye/backend/nutrition/dto/response/NutritionAiResponse.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 public record NutritionAiResponse(
         @Schema(description = "영양성분 정보 포함 여부")
         Boolean isNutrientIncluded,
+        @Schema(description = "영양성분 도출 기준 함량")
+        Integer nutrientReferenceAmount,
+
         @Schema(description = "나트륨 (mg)", example = "120.5")
         Double sodium,
         @Schema(description = "탄수화물 (g)", example = "25.0")

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -46,7 +46,7 @@ public class ProductService {
 
             return ProductResponse.builder()
                     .allergyTypes(getAllergyResponse(product, request.allergies()))
-                    .nutrientResponse(getNutrientRecommendationResponse(request, product))
+                    .nutrientResponse(getNutrientResponse(request, product))
                     .build();
         }
         Product product = Product.builder()
@@ -59,7 +59,7 @@ public class ProductService {
 
         return ProductResponse.builder()
                 .allergyTypes(getAllergyResponse(product, request.allergies()))
-                .nutrientResponse(getNutrientRecommendationResponse(request, product))
+                .nutrientResponse(getNutrientResponse(request, product))
                 .build();
     }
 
@@ -71,7 +71,7 @@ public class ProductService {
                 .toList();
     }
 
-    private NutrientResponse getNutrientRecommendationResponse(
+    private NutrientResponse getNutrientResponse(
             FoodProductAnalysisRequest request, Product product) {
         return NutrientResponse.builder()
                 .nutrientReferenceAmount(product.getNutrientReferenceAmount())

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -3,13 +3,13 @@ package com.webeye.backend.product.application;
 import com.webeye.backend.allergy.application.AllergyService;
 import com.webeye.backend.allergy.type.AllergyType;
 import com.webeye.backend.imageanalysis.infrastructure.ImageUrlExtractor;
+import com.webeye.backend.nutrition.dto.response.NutrientResponse;
 import com.webeye.backend.product.dto.response.DetailExplanationResponse;
 import com.webeye.backend.global.error.BusinessException;
 import com.webeye.backend.global.error.ErrorCode;
 import com.webeye.backend.imageanalysis.infrastructure.OpenAiClient;
 import com.webeye.backend.nutrition.application.NutrientRecommendationService;
 import com.webeye.backend.nutrition.dto.request.NutrientRecommendationRequest;
-import com.webeye.backend.nutrition.dto.response.NutrientRecommendationResponse;
 import com.webeye.backend.product.domain.ProductAllergy;
 import com.webeye.backend.product.domain.type.OutlineType;
 import com.webeye.backend.product.dto.request.FoodProductAnalysisRequest;
@@ -46,7 +46,7 @@ public class ProductService {
 
             return ProductResponse.builder()
                     .allergyTypes(getAllergyResponse(product, request.allergies()))
-                    .overRecommendationNutrients(getNutrientRecommendationResponse(request, product))
+                    .nutrientResponse(getNutrientRecommendationResponse(request, product))
                     .build();
         }
         Product product = Product.builder()
@@ -59,7 +59,7 @@ public class ProductService {
 
         return ProductResponse.builder()
                 .allergyTypes(getAllergyResponse(product, request.allergies()))
-                .overRecommendationNutrients(getNutrientRecommendationResponse(request, product))
+                .nutrientResponse(getNutrientRecommendationResponse(request, product))
                 .build();
     }
 
@@ -71,10 +71,13 @@ public class ProductService {
                 .toList();
     }
 
-    private List<NutrientRecommendationResponse> getNutrientRecommendationResponse(
+    private NutrientResponse getNutrientRecommendationResponse(
             FoodProductAnalysisRequest request, Product product) {
-        return nutrientRecommendationService.analyzeNutrientSufficiency(NutrientRecommendationRequest
-                .builder().birthYear(request.birthYear()).gender(request.gender()).product(product).build());
+        return NutrientResponse.builder()
+                .nutrientReferenceAmount(product.getNutrientReferenceAmount())
+                .overRecommendationNutrients(nutrientRecommendationService.analyzeNutrientSufficiency(NutrientRecommendationRequest
+                        .builder().birthYear(request.birthYear()).gender(request.gender()).product(product).build()))
+                .build();
     }
 
     public DetailExplanationResponse analyzeProductDetail(OutlineType outline, ProductDetailAnalysisRequest request) {

--- a/src/main/java/com/webeye/backend/product/domain/Product.java
+++ b/src/main/java/com/webeye/backend/product/domain/Product.java
@@ -16,6 +16,8 @@ public class Product extends BaseEntity {
     @Column(name = "product_id", nullable = false)
     private String id; // 쿠팡에서 products 뒤에 오는 숫자
 
+    private Integer nutrientReferenceAmount;
+
     @OneToOne(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Review review;
 
@@ -29,8 +31,9 @@ public class Product extends BaseEntity {
     private List<ProductHealthfood> healthFoods = new ArrayList<>();
 
     @Builder
-    public Product(String id) {
+    public Product(String id, Integer nutrientReferenceAmount) {
         this.id = id;
+        this.nutrientReferenceAmount = nutrientReferenceAmount;
     }
 
     public void associateWithReview(Review review) {
@@ -53,5 +56,9 @@ public class Product extends BaseEntity {
     public void addHealthFood(ProductHealthfood healthFood) {
         this.healthFoods.add(healthFood);
         healthFood.associateWithProduct(this);
+    }
+
+    public void setNutrientReferenceAmount(Integer nutrientReferenceAmount) {
+        this.nutrientReferenceAmount = nutrientReferenceAmount;
     }
 }

--- a/src/main/java/com/webeye/backend/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/webeye/backend/product/dto/response/ProductResponse.java
@@ -1,7 +1,7 @@
 package com.webeye.backend.product.dto.response;
 
 import com.webeye.backend.allergy.type.AllergyType;
-import com.webeye.backend.nutrition.dto.response.NutrientRecommendationResponse;
+import com.webeye.backend.nutrition.dto.response.NutrientResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -13,7 +13,6 @@ public record ProductResponse (
         @Schema(description = "포함된 알레르기 유발 성분")
         List<AllergyType> allergyTypes,
 
-        @Schema(description = "영양성분 권장량을 넘는 성분")
-        List<NutrientRecommendationResponse> overRecommendationNutrients
+        NutrientResponse nutrientResponse
 ) {
 }

--- a/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
+++ b/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
@@ -7,7 +7,6 @@ import com.webeye.backend.nutrition.persistent.NutrientRepository;
 import com.webeye.backend.product.domain.Product;
 import com.webeye.backend.product.domain.ProductNutrient;
 import com.webeye.backend.product.dto.request.FoodProductAnalysisRequest;
-import com.webeye.backend.product.persistent.ProductRepository;
 import com.webeye.backend.rawmaterial.domain.RawMaterial;
 import com.webeye.backend.rawmaterial.persistent.RawMaterialRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +27,6 @@ public class RawMaterialService {
 
     private final RawMaterialRepository rawMaterialRepository;
     private final NutrientRepository nutrientRepository;
-    private final ProductRepository productRepository;
 
     @Transactional
     public void saveRawMaterialNutrition(Product product, FoodProductAnalysisRequest request) {

--- a/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
+++ b/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
@@ -32,6 +32,7 @@ public class RawMaterialService {
 
     @Transactional
     public void saveRawMaterialNutrition(Product product, FoodProductAnalysisRequest request) {
+        product.setNutrientReferenceAmount(100);
         String foodName = openAiClient.explainRawMaterial(request).name();
         Optional<RawMaterial> rawMaterialOpt = rawMaterialRepository.findFirstByNameContaining(foodName);
         rawMaterialOpt.ifPresentOrElse(rawMaterial -> {
@@ -52,7 +53,7 @@ public class RawMaterialService {
             productRepository.save(product);
         }, () -> log.warn("일치하는 원재료 데이터가 존재하지 않습니다."));
     }
-    
+
     private Map<NutrientType, Double> convertToNutrientMap(RawMaterial rawMaterial) {
         Map<NutrientType, Double> map = new EnumMap<>(NutrientType.class);
         map.put(NutrientType.SODIUM, rawMaterial.getSodium());

--- a/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
+++ b/src/main/java/com/webeye/backend/rawmaterial/application/RawMaterialService.java
@@ -49,8 +49,6 @@ public class RawMaterialService {
                                 .build()
                 );
             });
-
-            productRepository.save(product);
         }, () -> log.warn("일치하는 원재료 데이터가 존재하지 않습니다."));
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #71 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- OpenAI로 식품 영양성분 기준 함량을 추출했습니다.
- 영양성분 도출 기준 함량 필드를 Product에 추가했습니다. 원재료 식품은 공공데이터가 모두 100g 기준이라 100으로 고정했습니다.
- 추출한 함량을 식품 API 응답에 추가했습니다.

## 📸 스크린샷
<img width="1205" alt="스크린샷 2025-05-24 오후 5 05 32" src="https://github.com/user-attachments/assets/9114f624-61f7-4e2d-b29b-94e7b41bea52" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 영양성분 정보에 '영양성분 도출 기준 함량(gram)'이 추가되어, 영양성분 기준량을 확인할 수 있습니다.
    - 영양성분 초과 항목이 단일 객체(nutrientResponse)로 통합되어 응답됩니다.

- **버그 수정**
    - 일부 영양성분 저장 및 반환 로직이 개선되어, 기준 함량 정보가 누락되지 않도록 반영되었습니다.

- **API 변경**
    - 제품 상세 응답에서 영양성분 관련 필드 구조가 변경되었습니다. (overRecommendationNutrients → nutrientResponse)
    - 영양성분 분석 결과에 기준 함량(nutrientReferenceAmount)이 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->