### PR TITLE
fix: 모든 쿠팡 이미지 URL 형식 반영

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -17,16 +17,25 @@ public class ImageUrlExtractor {
     public List<String> extractImageUrlFromHtml(String html) {
         html = StringEscapeUtils.unescapeJava(html);
 
-        Pattern pattern = Pattern.compile("<img[^>]+src=[\"'](//[^\"']+)[\"']");
+        // http://, https://, // 모두 잡는 정규식
+        Pattern pattern = Pattern.compile("<img[^>]+src=[\"']((https?:)?//[^\"']+)[\"']");
         Matcher matcher = pattern.matcher(html);
 
         List<String> imageUrls = new ArrayList<>();
 
         while (matcher.find()) {
             String rawUrl = matcher.group(1);
-            String fullUrl = "https:" + rawUrl;
-            imageUrls.add(fullUrl);
+
+            if (rawUrl.startsWith("//")) {
+                rawUrl = "https:" + rawUrl;
+            }
+            else if (rawUrl.startsWith("http://")) {
+                rawUrl = rawUrl.replaceFirst("http://", "https://");
+            }
+
+            imageUrls.add(rawUrl);
         }
+
         log.info("extracted urls: {}", imageUrls);
         log.info("total number of images: {}", imageUrls.size());
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #86 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- html에서 image url을 추출하는 과정에서 `//thumbnail`, `https://thumnail`, `http://thumbnail` 모두 가능하도록 수정했습니다.
- OpenAI에 입력할 수 있도록 http로 시작하는 URL은 https로 변경했습니다.

## 📸 스크린샷
<img width="1206" alt="스크린샷 2025-05-27 오후 1 59 36" src="https://github.com/user-attachments/assets/cc792a39-21c5-49cc-aa59-90314d661f7e" />



## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이미지 URL 추출 시 "http://", "https://", "//"로 시작하는 다양한 형식을 올바르게 인식하도록 개선되었습니다.
  - 추출된 이미지 URL이 항상 "https://"로 정상적으로 변환되어 보안 연결이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->