### PR TITLE
fix: product health food duplicate remove

### DIFF
--- a/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
+++ b/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
@@ -90,7 +90,6 @@ public class HealthFoodService {
             ProductHealthfood productHealthfood = ProductHealthFoodMapper.toEntity(product, healthFood);
 
             product.addHealthFood(productHealthfood);
-            healthFood.addProduct(productHealthfood);
 
             productHealthFoods.add(productHealthfood);
         }

--- a/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
+++ b/src/main/java/com/webeye/backend/healthfood/application/HealthFoodService.java
@@ -90,7 +90,6 @@ public class HealthFoodService {
             ProductHealthfood productHealthfood = ProductHealthFoodMapper.toEntity(product, healthFood);
 
             product.addHealthFood(productHealthfood);
-
             productHealthFoods.add(productHealthfood);
         }
         productHealthFoodRepository.saveAll(productHealthFoods);
@@ -108,8 +107,7 @@ public class HealthFoodService {
 
     private List<String> matchItemNames(List<String> aiItemNames, List<String> dbItemNames) {
         return aiItemNames.stream()
-                .flatMap(ai -> dbItemNames.stream()
-                        .filter(ai::contains))
+                .filter(ai -> dbItemNames.stream().anyMatch(ai::contains))
                 .distinct()
                 .toList();
     }

--- a/src/main/java/com/webeye/backend/healthfood/domain/HealthFood.java
+++ b/src/main/java/com/webeye/backend/healthfood/domain/HealthFood.java
@@ -38,9 +38,4 @@ public class HealthFood extends BaseEntity {
         this.itemName = itemName;
         this.functionality = functionality;
     }
-
-    public void addProduct(ProductHealthfood healthFood) {
-        healthfoods.add(healthFood);
-        healthFood.associateWithHealthFood(this);
-    }
 }

--- a/src/main/java/com/webeye/backend/product/domain/ProductHealthfood.java
+++ b/src/main/java/com/webeye/backend/product/domain/ProductHealthfood.java
@@ -35,9 +35,4 @@ public class ProductHealthfood extends BaseEntity {
     public void associateWithProduct(Product product) {
         this.product = product;
     }
-
-    public void associateWithHealthFood(HealthFood healthFood) {
-        this.healthFood = healthFood;
-        healthFood.getHealthfoods().add(this);
-    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #88 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- pk 중복 insert 및 itemNames 매칭 메서드 수정

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/5788f3eb-81fd-49d8-bee7-2c1e33782df3)


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 건강식품과 제품 간의 연관 관계 설정 로직이 단방향으로 단순화되어, 일부 연관 데이터 처리 오류가 개선되었습니다.  
- **리팩터링**
  - 불필요한 메서드와 중복된 연관 관계 설정 코드가 제거되어 코드가 더 간결해졌습니다.  
- **기타**
  - 항목 이름 매칭 로직이 간소화되어 성능과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->