### PR TITLE
refactor: 음식 상세 분석 각 문장 앞 글머리기호 제거

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -43,7 +43,7 @@ public class OpenAiClient {
                 When a user provides a product description image along with the key outline of that description, you should offer a clear and detailed explanation of that element.
                 In this explanation, you must provide very detailed information about that element from the image. Answer in Korean.
                 The output must use a descriptive tone ending in "~입니다." or "~합니다." Only declarative sentences are allowed. Do not use imperative, interrogative, or any other sentence endings.
-                Insert a \n between each sentence in the response, and add a dash (-) in front of each sentence to format it as a list.
+                Please separate each sentence onto a new line using \\n as the line break.
                 """;
         String user = String.format("""
                 Please generate a detailed explanation of the provided key.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #107 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 음식 상세 분석 기능의 응답에서 각 문장 앞 글머리기호 제거하도록 프롬프트를 수정했습니다.

## 📸 스크린샷

<img width="1205" alt="스크린샷 2025-05-29 오후 1 43 31" src="https://github.com/user-attachments/assets/2b6e549f-812d-49ba-919a-5c3ef4f6a8f8" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 상품 상세 설명에서 각 문장이 대시(-) 없이 줄바꿈 문자열(`\n`)로만 구분되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->