### PR TITLE
fix: OpenAI 이미지 요청 개수 20개로 제한

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -12,10 +12,28 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class ImageUrlExtractor {
-    public static List<String> extractImageUrlFromHtml(String html) {
-        html = StringEscapeUtils.unescapeJava(html);
+    private static final int MAX_IMAGE_COUNT = 20;
 
-        // http://, https://, // 모두 잡는 정규식
+    public static List<String> extractImageUrlFromHtml(String html) {
+        String unescapedHtml = unescapeHtml(html);
+        List<String> imageUrls = extractImageUrls(unescapedHtml);
+        List<String> trimmedUrls = trimToMaxSize(imageUrls, MAX_IMAGE_COUNT);
+
+        log.info("extracted urls: {}", trimmedUrls);
+        log.info("total number of images: {}", trimmedUrls.size());
+
+        if (trimmedUrls.isEmpty()) {
+            throw new BusinessException(ErrorCode.IMAGE_URL_NOT_FOUND);
+        }
+
+        return trimmedUrls;
+    }
+
+    private static String unescapeHtml(String html) {
+        return StringEscapeUtils.unescapeJava(html);
+    }
+
+    private static List<String> extractImageUrls(String html) {
         Pattern pattern = Pattern.compile("<img[^>]+src=[\"']((https?:)?//[^\"']+)[\"']");
         Matcher matcher = pattern.matcher(html);
 
@@ -26,20 +44,20 @@ public class ImageUrlExtractor {
 
             if (rawUrl.startsWith("//")) {
                 rawUrl = "https:" + rawUrl;
-            }
-            else if (rawUrl.startsWith("http://")) {
+            } else if (rawUrl.startsWith("http://")) {
                 rawUrl = rawUrl.replaceFirst("http://", "https://");
             }
 
             imageUrls.add(rawUrl);
         }
 
-        log.info("extracted urls: {}", imageUrls);
-        log.info("total number of images: {}", imageUrls.size());
-
-        if (imageUrls.isEmpty()) {
-            throw new BusinessException(ErrorCode.IMAGE_URL_NOT_FOUND);
-        }
         return imageUrls;
+    }
+
+    private static List<String> trimToMaxSize(List<String> urls, int maxSize) {
+        if (urls.size() <= maxSize) {
+            return urls;
+        }
+        return new ArrayList<>(urls.subList(urls.size() - maxSize, urls.size()));
     }
 }

--- a/src/main/java/com/webeye/backend/product/application/ProductService.java
+++ b/src/main/java/com/webeye/backend/product/application/ProductService.java
@@ -34,6 +34,7 @@ public class ProductService {
 
     @Transactional
     public ProductResponse analyzeFoodProduct(FoodProductAnalysisRequest request) {
+        log.info("[ProductService] 📌 requested product ID: {}", request.productId());
         if (productRepository.existsById(request.productId())) {
             Product product = productRepository.findById(request.productId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/webeye/backend/productdetail/application/ProductDetailService.java
+++ b/src/main/java/com/webeye/backend/productdetail/application/ProductDetailService.java
@@ -29,6 +29,7 @@ public class ProductDetailService {
 
     @Transactional
     public DetailExplanationResponse analyzeProductDetail(OutlineType outline, ProductDetailAnalysisRequest request) {
+        log.info("[ProductDetailService] 📌 requested product ID: {}", request.productId());
         Optional<ProductDetail> productDetailOpt = productDetailRepository.findByProductIdAndOutline(request.productId(), outline);
         if (productDetailOpt.isEmpty()) {
             AllDetailExplanationResponse details = openAiClient.explainProductAllDetail(ImageUrlExtractor.extractImageUrlFromHtml(request.html()));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #109 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- OpenAI 이미지 요청 개수 20개로 제한했습니다.
- Product ID를 확인하는 Log를 추가했습니다.

## 📸 스크린샷
<img width="1213" alt="스크린샷 2025-05-29 오후 2 22 24" src="https://github.com/user-attachments/assets/81c6c52a-0e6b-4e66-953c-05b6525d52c5" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 이미지 URL 추출 시 최대 20개까지만 결과를 반환하도록 개선되었습니다. 만약 유효한 이미지 URL이 없을 경우 오류가 발생합니다.

- **기타**
  - 식품 및 제품 상세 분석 요청 시, 요청된 상품 ID가 로그에 기록됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->