### PR TITLE
fix: OpenAI 분석 이미지 개수 15개로 제한

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class ImageUrlExtractor {
-    private static final int MAX_IMAGE_COUNT = 20;
+    private static final int MAX_IMAGE_COUNT = 15;
 
     public static List<String> extractImageUrlFromHtml(String html) {
         String unescapedHtml = unescapeHtml(html);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #112 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- OpenAI 분석 이미지 개수 15개로 제한

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 한 번에 추출 및 반환되는 이미지 URL의 최대 개수가 20개에서 15개로 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->