### PR TITLE
fix: OpenAI 반환 형식 강제

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class ImageUrlExtractor {
-    private static final int MAX_IMAGE_COUNT = 15;
+    private static final int MAX_IMAGE_COUNT = 10;
 
     public static List<String> extractImageUrlFromHtml(String html) {
         String unescapedHtml = unescapeHtml(html);

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -66,20 +66,20 @@ public class OpenAiClient {
 
         String user = """
                 Step 1: Carefully examine the attached image(s).
-                
+                                
                 Identify the box that contains the full list of ingredients, labeled with '원재료명' or similar (e.g., '원재료 및 함량').
-                
                 Only extract text from this box — ignore all other parts of the image, including allergy warnings or separate notices.
-                
+                If there is no match or anything similar, skip to Step 4 and set the value of all keys to false.
+                                
                 Step 2: From the identified box, extract the ingredient list **exactly as written**, without summarizing, translating, or omitting anything — including words like '분말', '가루', or '함유'.
-                
+                                
                 Step 3: Compare the text to the following list of allergenic ingredients:
                 계란(EGG), 우유(MILK), 메밀(BUCKWHEAT), 땅콩(PEANUT), 대두(SOYBEAN), 밀(WHEAT), 잣(PINE_NUT), 호두(WALNUT), 게(CRAB), 새우(SHRIMP), 오징어(SQUID), 고등어(MACKEREL), 조개(SHELLFISH), 복숭아(PEACH), 토마토(TOMATO), 닭고기(CHICKEN), 돼지고기(PORK), 쇠고기(BEEF), 아황산류(SULFITE).
 
                 Return true for an allergen if its full Korean name appears **anywhere inside any word** in the ingredient list — even if it is part of a compound word (e.g., "호두함유", "호두분말", "밀가루").
-                
+                                
                 Return false if the full Korean allergen word does not appear in any part of the ingredient text.
-                
+                                
                 Step 4: Output a list of booleans (true/false), in the same order as the allergen list above.
                  """;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #114 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 이미지를 인식하지 못하는 경우 핸들링

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
  - 이미지 URL 추출 시 최대 개수가 15개에서 10개로 감소하여, 한 번에 반환되는 이미지 수가 줄어들었습니다.
  - 알레르기 설명 프롬프트에 추가 안내 문구와 공백이 추가되어, 원재료명 박스가 없을 때 모든 알레르기 플래그를 false로 처리하도록 명확하게 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->