### PR TITLE
fix: 이미지 한도 개수 조정

### DIFF
--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/ImageUrlExtractor.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class ImageUrlExtractor {
-    private static final int MAX_IMAGE_COUNT = 10;
+    private static final int MAX_IMAGE_COUNT = 6;
 
     public static List<String> extractImageUrlFromHtml(String html) {
         String unescapedHtml = unescapeHtml(html);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #116 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 이미지 한도 개수 조정했습니다.

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 한 번에 추출되는 이미지 URL의 최대 개수가 10개에서 6개로 줄어들었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->