### PR TITLE
fix: 이미지 url을 이미지 확장자로 끝나도록 함

### DIFF
--- a/src/main/java/com/webeye/backend/global/error/ErrorCode.java
+++ b/src/main/java/com/webeye/backend/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     FILE_EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "URL에서 확장자를 찾을 수 없습니다."),
     UNSUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL입니다."),
+    NO_IMAGE_FILE_EXTENSION_FOUND(HttpStatus.BAD_REQUEST, "이미지 확장자가 없습니다."),
 
     // image url extract
     IMAGE_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지의 URL이 추출되지 않았습니다."),

--- a/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/infrastructure/OpenAiClient.java
@@ -27,8 +27,7 @@ import org.springframework.util.MimeType;
 import java.net.MalformedURLException;
 import java.util.List;
 
-import static com.webeye.backend.global.error.ErrorCode.FILE_EXTENSION_NOT_FOUND;
-import static com.webeye.backend.global.error.ErrorCode.INVALID_IMAGE_URL;
+import static com.webeye.backend.global.error.ErrorCode.*;
 
 @Slf4j
 @Component
@@ -202,7 +201,8 @@ public class OpenAiClient {
                 """;
 
         ImageAnalysisPrompt prompt = new ImageAnalysisPrompt(system, user);
-        return callWithStructuredOutput(List.of(request.url()), prompt, ImageAnalysisResponse.class);
+
+        return callWithStructuredOutput(List.of(trimImageUrl(request.url())), prompt, ImageAnalysisResponse.class);
     }
 
     private <T> T callWithStructuredOutput(List<String> urls, ImageAnalysisPrompt prompt, Class<T> clazz) {
@@ -235,6 +235,18 @@ public class OpenAiClient {
             throw new BusinessException(FILE_EXTENSION_NOT_FOUND);
         }
         return fileName.substring(dotIndex + 1);
+    }
+
+    private String trimImageUrl(String url) {
+        for (ImageMimeType type : ImageMimeType.values()) {
+            String extension = "." + type.name().toLowerCase();
+            int index = url.toLowerCase().indexOf(extension);
+            if (index != -1) {
+                int endIndex = index + extension.length();
+                return url.substring(0, endIndex);
+            }
+        }
+        throw new BusinessException(NO_IMAGE_FILE_EXTENSION_FOUND);
     }
 
 

--- a/src/main/java/com/webeye/backend/imageanalysis/presentation/swagger/ImageAnalysisSwagger.java
+++ b/src/main/java/com/webeye/backend/imageanalysis/presentation/swagger/ImageAnalysisSwagger.java
@@ -19,6 +19,10 @@ public interface ImageAnalysisSwagger {
             @ApiResponse(
                     responseCode = "200",
                     description = "이미지가 성공적으로 분석되었습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이미지 확장자가 없습니다."
             )
     })
     SuccessResponse<ImageAnalysisResponse> imageAnalysis(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #136

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- `trimImageUrl()` 구현
- URI에 이미지 확장자가 없는 경우 예외처리

## 📸 스크린샷
<img width="1220" alt="스크린샷 2025-05-31 오전 1 47 05" src="https://github.com/user-attachments/assets/745bae62-6246-403b-9d3c-1b1ce63a91bf" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이미지 파일 확장자가 없는 경우에 대한 새로운 오류 메시지가 추가되었습니다.
- **문서화**
  - 이미지 분석 API에 이미지 확장자가 없을 때의 오류 응답(400) 안내가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->